### PR TITLE
feat: add pagination and authorization for artifact endpoints

### DIFF
--- a/src/main/java/ro/ubb/abc2024/arheo/controller/artifact/ArtifactController.java
+++ b/src/main/java/ro/ubb/abc2024/arheo/controller/artifact/ArtifactController.java
@@ -1,14 +1,24 @@
 package ro.ubb.abc2024.arheo.controller.artifact;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+import ro.ubb.abc2024.arheo.domain.artifact.Artifact;
 import ro.ubb.abc2024.arheo.service.ArtifactService;
 import ro.ubb.abc2024.arheo.utils.converter.ArtifactDtoConverter;
 import ro.ubb.abc2024.arheo.utils.dto.ArtifactDto;
+import ro.ubb.abc2024.user.User;
+import ro.ubb.abc2024.user.UserService;
 import ro.ubb.abc2024.utils.dto.Result;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
@@ -17,13 +27,42 @@ import java.util.stream.Collectors;
 public class ArtifactController {
     private final ArtifactService artifactService;
     private final ArtifactDtoConverter artifactDtoConverter;
+    private final UserService userService;
 
     // get all artifacts
-    @GetMapping
+    /*@GetMapping
     public Result<List<ArtifactDto>> getArtifacts() {
         return new Result<>(true, HttpStatus.OK.value(), "Retrieved all artifacts", artifactService.getAllArtifacts().stream()
                 .map(artifactDtoConverter::createFromEntity)
                 .collect(Collectors.toList()));
+    }*/
+
+    // get all artifacts paginated and filtered by whatever fields we want
+    @GetMapping
+    @PreAuthorize("hasAnyAuthority('SCOPE_ARH', 'SCOPE_ADMIN', 'SCOPE_BIO')")
+    public Result<Map<String,Object>> getArtifacts(@RequestParam(required = false) Long siteId,
+                                                   @RequestParam(required = false) Long sectionId,
+                                                   @RequestParam(required = false) Long archaeologistId,
+                                                   @RequestParam(required = false) String label,
+                                                   @RequestParam(required = false) String category,
+                                                   @RequestParam(required = false) Boolean analysisCompleted,
+                                                   @RequestParam(required = false) Boolean selfSubmitted,
+                                                   @RequestParam(defaultValue = "0") int page,
+                                                   @RequestParam(defaultValue = "5") int size) {
+        if (selfSubmitted) {
+            var currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+            archaeologistId = userService.getUser(currentUser).getId();
+        }
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Artifact> artifactPage = artifactService.getAllPaginatedByCriteria(siteId, sectionId, archaeologistId, label, category, analysisCompleted, pageable);
+        List<ArtifactDto> artifactDtoList = artifactPage.getContent().stream().map(artifactDtoConverter::createFromEntity)
+                .collect(Collectors.toList());
+        Map<String, Object> response = new HashMap<>();
+        response.put("artifacts", artifactDtoList);
+        response.put("currentPage", artifactPage.getNumber());
+        response.put("totalItems", artifactPage.getTotalElements());
+        response.put("totalPages", artifactPage.getTotalPages());
+        return new Result<>(true, HttpStatus.OK.value(), "Retrieved all artifacts", response);
     }
 
     // get an artifact by its id
@@ -34,26 +73,57 @@ public class ArtifactController {
 
     // add a new artifact
     @PostMapping
+    @PreAuthorize("hasAnyAuthority('SCOPE_ARH', 'SCOPE_ADMIN')")
     public Result<ArtifactDto> addArtifact(@RequestBody ArtifactDto artifactDto) {
+        Long sectionId = artifactDto.sectionId();
+        Long mainArchaeologistId = artifactService.getMainArchaeologistIdFromSectionId(sectionId);
+        List<Long> assignedArchaeologistIds = artifactService.getAssignedArchaeologistIdsBySectionId(sectionId);
+
+        var currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        Long currentUserId = userService.getUser(currentUser).getId();
+
+        if (!mainArchaeologistId.equals(currentUserId) || !assignedArchaeologistIds.contains(currentUserId)) {
+            return new Result<>(false, HttpStatus.FORBIDDEN.value(), "You do not have permission to add this artifact", null);
+        }
         var artifact = artifactService.addArtifact(artifactDtoConverter.createFromDto(artifactDto));
         return new Result<>(true, HttpStatus.CREATED.value(), "Added artifact", artifactDtoConverter.createFromEntity(artifact));
     }
 
     // delete an artifact
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasAnyAuthority('SCOPE_ARH', 'SCOPE_ADMIN')")
     public Result<Void> deleteArtifact(@PathVariable long id) {
+        Artifact existingArtifact = artifactService.getArtifactById(id);
+        Long mainArchaeologistId = artifactService.getMainArchaeologistIdFromArtifactId(existingArtifact.getId());
+
+        var currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        Long currentUserId = userService.getUser(currentUser).getId();
+
+        if (!existingArtifact.getArcheologist().getId().equals(currentUserId) || !mainArchaeologistId.equals(currentUserId)) {
+            return new Result<>(false, HttpStatus.FORBIDDEN.value(), "You do not have permission to delete this artifact", null);
+        }
         artifactService.deleteArtifact(id);
         return new Result<>(true, HttpStatus.NO_CONTENT.value(), "Deleted artifact", null);
     }
 
     // update an artifact
     @PutMapping
+    @PreAuthorize("hasAnyAuthority('SCOPE_ARH', 'SCOPE_ADMIN')")
     public Result<ArtifactDto> updateArtifact(@RequestBody ArtifactDto artifactDto) {
-        var artifact = artifactService.updateArtifact(artifactDtoConverter.createFromDto(artifactDto));
+        Artifact existingArtifact = artifactService.getArtifactById(artifactDto.id());
+        Long mainArchaeologistId = artifactService.getMainArchaeologistIdFromArtifactId(existingArtifact.getId());
+
+        var currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        Long currentUserId = userService.getUser(currentUser).getId();
+
+        if (!existingArtifact.getArcheologist().getId().equals(currentUserId) || !mainArchaeologistId.equals(currentUserId)) {
+            return new Result<>(false, HttpStatus.FORBIDDEN.value(), "You do not have permission to edit this artifact", null);
+        }
+        Artifact artifact = artifactService.updateArtifact(artifactDtoConverter.createFromDto(artifactDto));
         return new Result<>(true, HttpStatus.OK.value(), "Updated artifact", artifactDtoConverter.createFromEntity(artifact));
     }
 
-    // get all artifacts for an archaeologist
+    /*// get all artifacts for an archaeologist
     @GetMapping("/by-archeologist")
     public Result<List<ArtifactDto>> getArtifactsByArcheologistId(@RequestParam Long archaeologistId) {
         return new Result<>(true, HttpStatus.OK.value(), "Retrieved all artifacts for an archeologist",
@@ -105,5 +175,5 @@ public class ArtifactController {
                 artifactService.getArtifactsBySectionId(sectionId).stream()
                         .map(artifactDtoConverter::createFromEntity)
                         .collect(Collectors.toList()));
-    }
+    }*/
 }

--- a/src/main/java/ro/ubb/abc2024/arheo/repository/ArtifactRepository.java
+++ b/src/main/java/ro/ubb/abc2024/arheo/repository/ArtifactRepository.java
@@ -1,6 +1,7 @@
 package ro.ubb.abc2024.arheo.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -10,7 +11,7 @@ import ro.ubb.abc2024.user.User;
 import java.util.List;
 
 @Repository
-public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
+public interface ArtifactRepository extends JpaRepository<Artifact, Long>, JpaSpecificationExecutor<Artifact> {
     List<Artifact> findArtifactsByLabScanIsNull();
     //List<Artifact> findArtifactsByArcheologist(User archeologist);
     List<Artifact> findArtifactsByArcheologist_Id(Long id);
@@ -18,4 +19,10 @@ public interface ArtifactRepository extends JpaRepository<Artifact, Long> {
     List<Artifact> findArtifactsBySection_Site_Id(Long id);
     List<Artifact> findArtifactsByCategory(String category);
     List<Artifact> findArtifactsBySection_Site_IdAndArcheologist_Id(Long siteId, Long archeologistId);
+    @Query("select a.section.site.mainArchaeologist.id from Artifact a where a.id = :id")
+    Long findMainArcheologistIdByArtifactId(@Param("id") Long id);
+    @Query("select a.section.site.mainArchaeologist.id from Artifact a where a.section.id = :id")
+    Long findMainArcheologistIdBySectionId(@Param("id") Long id);
+    @Query("SELECT a.section.site.archaeologists from Artifact a WHERE a.section.id = :id")
+    List<User> findAssignedArchaeologistIdsBySectionId(@Param("id") Long id);
 }

--- a/src/main/java/ro/ubb/abc2024/arheo/service/ArtifactService.java
+++ b/src/main/java/ro/ubb/abc2024/arheo/service/ArtifactService.java
@@ -1,6 +1,9 @@
 package ro.ubb.abc2024.arheo.service;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import ro.ubb.abc2024.arheo.domain.artifact.Artifact;
+import ro.ubb.abc2024.user.User;
 
 import java.util.List;
 
@@ -16,4 +19,8 @@ public interface ArtifactService {
     List<Artifact> getArtifactsBySiteId(Long id);
     List<Artifact> getArtifactsBySiteIdAndArcheologistId(Long siteId, Long archeologistId);
     List<Artifact> getArtifactsByCategory(String category);
+    Page<Artifact> getAllPaginatedByCriteria(Long siteId, Long sectionId, Long archaeologistId, String label, String category, Boolean analysisCompleted, Pageable pageable);
+    Long getMainArchaeologistIdFromArtifactId(Long id);
+    List<Long> getAssignedArchaeologistIdsBySectionId(Long id);
+    Long getMainArchaeologistIdFromSectionId(Long id);
 }

--- a/src/main/java/ro/ubb/abc2024/arheo/service/ArtifactServiceImpl.java
+++ b/src/main/java/ro/ubb/abc2024/arheo/service/ArtifactServiceImpl.java
@@ -1,17 +1,26 @@
 package ro.ubb.abc2024.arheo.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
 import jakarta.transaction.Transactional;
 import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import ro.ubb.abc2024.arheo.domain.artifact.Artifact;
+import ro.ubb.abc2024.arheo.domain.section.Section;
+import ro.ubb.abc2024.arheo.domain.site.Site;
 import ro.ubb.abc2024.arheo.exception.ArtifactServiceException;
 import ro.ubb.abc2024.arheo.repository.ArtifactRepository;
 import ro.ubb.abc2024.user.User;
 import ro.ubb.abc2024.utils.validation.GenericValidator;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+
 
 @RequiredArgsConstructor
 @Service
@@ -98,5 +107,52 @@ public class ArtifactServiceImpl implements ArtifactService {
     @Override
     public List<Artifact> getArtifactsByCategory(String category) {
         return artifactRepository.findArtifactsByCategory(category);
+    }
+
+    @Override
+    public Page<Artifact> getAllPaginatedByCriteria(Long siteId, Long sectionId, Long archaeologistId, String label, String category, Boolean analysisCompleted, Pageable pageable) {
+        return artifactRepository.findAll((root, query, criteriaBuilder) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            if (siteId != null) {
+                Join<Artifact, Section> artifactSectionJoin = root.join("section");
+                Join<Section, Site> sectionSiteJoin = artifactSectionJoin.join("site");
+                predicates.add(criteriaBuilder.equal(sectionSiteJoin.get("id"), siteId));
+            }
+            if (sectionId != null) {
+                Join<Artifact, Section> artifactSectionJoin = root.join("section");
+                predicates.add(criteriaBuilder.equal(artifactSectionJoin.get("id"), sectionId));
+            }
+            if (archaeologistId != null) {
+                Join<Artifact, User> artifactUserJoin = root.join("archeologist");
+                predicates.add(criteriaBuilder.equal(artifactUserJoin.get("id"), archaeologistId));
+            }
+            if (label != null) {
+                predicates.add(criteriaBuilder.like(root.get("label"),  "%" + label + "%"));
+            }
+            if (category != null) {
+                predicates.add(criteriaBuilder.equal(root.get("category"), category));
+            }
+            if (analysisCompleted != null) {
+                predicates.add(criteriaBuilder.equal(root.get("analysisCompleted"), analysisCompleted));
+            }
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        }, pageable);
+    }
+
+    @Override
+    public Long getMainArchaeologistIdFromArtifactId(Long id) {
+        return artifactRepository.findMainArcheologistIdByArtifactId(id);
+    }
+
+    @Override
+    public List<Long> getAssignedArchaeologistIdsBySectionId(Long id) {
+        List<User> archaeologists = artifactRepository.findAssignedArchaeologistIdsBySectionId(id);
+        return archaeologists.stream().map(User::getId).toList();
+    }
+
+    @Override
+    public Long getMainArchaeologistIdFromSectionId(Long id) {
+        return artifactRepository.findMainArcheologistIdBySectionId(id);
     }
 }


### PR DESCRIPTION
Implemented a method in service called "getAllPaginatedByCriteria" to support pagination and filtering of artifacts based on multiple optional criteria. Instead of having multiple endpoints, I integrated this in the controller for the endpoint "/artifacts" and each field to filter by is now a parameter. There is also a parameter called "selfSubmitted" which can be true or false: if it is false, the current user can see all artifacts, and if it is true, he can see only the artifacts he added.

Added authorization for the following endpoints:
for adding an artifacts - before adding it, it checks if the current user that wants to add it is the main archaeologist for that site or is assigned to it for editing an artifact - it checks if the archaeologist that wants to edit it is the one that added it before or if he is the main archaeologist for deleting an artifact - the logic is the same for this: an artifact can be deleted only by the archaeologist that added it or the main one